### PR TITLE
fix readme; SCREENSHOTS.md is not an image, it's a link :)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Currently, only the Dark Theme is available.
 
 ## Screenshots
 
-See ![SCREENSHOTS.md](https://github.com/beastdestroyer/vscode-firefox-quantum-themes/blob/master/test%20files/screenshots/SCREENSHOTS.md)
+See [SCREENSHOTS.md](https://github.com/beastdestroyer/vscode-firefox-quantum-themes/blob/master/test%20files/screenshots/SCREENSHOTS.md)
 
 ## CHANGELOG
 


### PR DESCRIPTION
This is how it looks before the change i submit here:

![image](https://user-images.githubusercontent.com/6356150/50048031-34bd7e00-00c2-11e9-8f4e-4c0c6663f039.png)

It sould look like the link to the `change log` on the bottom of the screenshot